### PR TITLE
Fix ssh clone issue

### DIFF
--- a/mdtemplate/tests/test_repo.py
+++ b/mdtemplate/tests/test_repo.py
@@ -1,0 +1,27 @@
+import unittest
+
+from ..utils.repo import Repository
+
+
+class RepositoryTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._repo = Repository()
+
+    @unittest.mock.patch('subprocess.check_output')
+    def test_git_cloned_by_https(self, mock_url):
+        mock_url.return_value = b'https://github.com/jcwillox/md-template.git\n'
+
+        self._repo.load_url()
+
+        self.assertEqual(self._repo.name, "md-template")
+        self.assertEqual(self._repo.owner, "jcwillox")
+
+    @unittest.mock.patch('subprocess.check_output')
+    def test_git_cloned_by_ssh(self, mock_url):
+        mock_url.return_value = b'git@github.com:jcwillox/md-template.git\n'
+
+        self._repo.load_url()
+
+        self.assertEqual(self._repo.name, "md-template")
+        self.assertEqual(self._repo.owner, "jcwillox")

--- a/mdtemplate/tests/test_repo.py
+++ b/mdtemplate/tests/test_repo.py
@@ -4,22 +4,21 @@ from ..utils.repo import Repository
 
 
 class RepositoryTest(unittest.TestCase):
-
     def setUp(self) -> None:
         self._repo = Repository()
 
-    @unittest.mock.patch('subprocess.check_output')
+    @unittest.mock.patch("subprocess.check_output")
     def test_git_cloned_by_https(self, mock_url):
-        mock_url.return_value = b'https://github.com/jcwillox/md-template.git\n'
+        mock_url.return_value = b"https://github.com/jcwillox/md-template.git\n"
 
         self._repo.load_url()
 
         self.assertEqual(self._repo.name, "md-template")
         self.assertEqual(self._repo.owner, "jcwillox")
 
-    @unittest.mock.patch('subprocess.check_output')
+    @unittest.mock.patch("subprocess.check_output")
     def test_git_cloned_by_ssh(self, mock_url):
-        mock_url.return_value = b'git@github.com:jcwillox/md-template.git\n'
+        mock_url.return_value = b"git@github.com:jcwillox/md-template.git\n"
 
         self._repo.load_url()
 

--- a/mdtemplate/utils/repo.py
+++ b/mdtemplate/utils/repo.py
@@ -3,7 +3,8 @@ import re
 import subprocess
 from typing import List
 
-_RE_REPO_URL = re.compile(r"https?://(?P<domain>.+)/(?P<owner>.+)/(?P<name>.+)")
+_RE_REPO_URL_BY_HTTPS = re.compile(r"https?://(?P<domain>.+)/(?P<owner>.+)/(?P<name>.+)")
+_RE_REPO_URL_BY_SSH = re.compile(r"git@(?P<domain>.+)/(?P<owner>.+)/(?P<name>.+)")
 
 
 class Repository:
@@ -58,7 +59,7 @@ class Repository:
             .decode()
         )
 
-        match = _RE_REPO_URL.match(self._url)
+        match = _RE_REPO_URL_BY_HTTPS.match(self._url) or _RE_REPO_URL_BY_SSH.match(self._url)
 
         self._name = match.group("name")
         self._owner = match.group("owner")

--- a/mdtemplate/utils/repo.py
+++ b/mdtemplate/utils/repo.py
@@ -4,7 +4,7 @@ import subprocess
 from typing import List
 
 _RE_REPO_URL_BY_HTTPS = re.compile(r"https?://(?P<domain>.+)/(?P<owner>.+)/(?P<name>.+)")
-_RE_REPO_URL_BY_SSH = re.compile(r"git@(?P<domain>.+)/(?P<owner>.+)/(?P<name>.+)")
+_RE_REPO_URL_BY_SSH = re.compile(r"git@(?P<domain>.+):(?P<owner>.+)/(?P<name>.+)")
 
 
 class Repository:

--- a/mdtemplate/utils/repo.py
+++ b/mdtemplate/utils/repo.py
@@ -3,8 +3,10 @@ import re
 import subprocess
 from typing import List
 
-_RE_REPO_URL_BY_HTTPS = re.compile(r"https?://(?P<domain>.+)/(?P<owner>.+)/(?P<name>.+)")
-_RE_REPO_URL_BY_SSH = re.compile(r"git@(?P<domain>.+):(?P<owner>.+)/(?P<name>.+)")
+_RE_REPO_URL_HTTPS = re.compile(
+    r"https?://(?P<domain>.+)/(?P<owner>.+)/(?P<name>.+)"
+)
+_RE_REPO_URL_SSH = re.compile(r"git@(?P<domain>.+):(?P<owner>.+)/(?P<name>.+)")
 
 
 class Repository:
@@ -59,7 +61,9 @@ class Repository:
             .decode()
         )
 
-        match = _RE_REPO_URL_BY_HTTPS.match(self._url) or _RE_REPO_URL_BY_SSH.match(self._url)
+        match = _RE_REPO_URL_HTTPS.match(self._url) or _RE_REPO_URL_SSH.match(
+            self._url
+        )
 
         self._name = match.group("name")
         self._owner = match.group("owner")

--- a/mdtemplate/utils/repo.py
+++ b/mdtemplate/utils/repo.py
@@ -3,9 +3,7 @@ import re
 import subprocess
 from typing import List
 
-_RE_REPO_URL_HTTPS = re.compile(
-    r"https?://(?P<domain>.+)/(?P<owner>.+)/(?P<name>.+)"
-)
+_RE_REPO_URL_HTTPS = re.compile(r"https?://(?P<domain>.+)/(?P<owner>.+)/(?P<name>.+)")
 _RE_REPO_URL_SSH = re.compile(r"git@(?P<domain>.+):(?P<owner>.+)/(?P<name>.+)")
 
 
@@ -61,9 +59,7 @@ class Repository:
             .decode()
         )
 
-        match = _RE_REPO_URL_HTTPS.match(self._url) or _RE_REPO_URL_SSH.match(
-            self._url
-        )
+        match = _RE_REPO_URL_HTTPS.match(self._url) or _RE_REPO_URL_SSH.match(self._url)
 
         self._name = match.group("name")
         self._owner = match.group("owner")


### PR DESCRIPTION
Whenever someone that wants to build/run any package that relies on `md-template` as dependency it needs to necessarily clone the repo using `https` and not `ssh`.

This PR tries to fix that
Unit Tests also added to make sure this doesn't happen again